### PR TITLE
Correct typo in 'Tokyo Olympics' event label

### DIFF
--- a/lookups/covid19events.csv
+++ b/lookups/covid19events.csv
@@ -86,7 +86,7 @@ date,annotation_label,category,world_usa,eventid,annotation_color
 3/21/2020,,,,84,
 3/22/2020,,,,85,
 3/23/2020,WA state issues shelter in place,,usa,86,#505158
-3/24/2020,Toyko Olympics delayed until 2021,sports,world,87,#505158
+3/24/2020,Tokyo Olympics delayed until 2021,sports,world,87,#505158
 3/25/2020,,,,88,
 3/26/2020,,,,89,
 3/27/2020,,,,90,


### PR DESCRIPTION
Noticed message with a typo on "Top 25 Countries with Confirmed Cases" while browsing https://covid-19.splunkforgood.com/coronavirus__covid_19_ 