### PR TITLE
Some minor internal error message cleanup.

### DIFF
--- a/bin/update_daily.sh
+++ b/bin/update_daily.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 cd $SPLUNK_HOME/etc/apps/corona_virus/lookups/
 ln -f -s ../git/COVID-19/csse_covid_19_data/csse_covid_19_daily_reports/`ls -v ../git/COVID-19/csse_covid_19_data/csse_covid_19_daily_reports/ | grep -v README | tail -n 1` latest_daily.csv

--- a/bin/update_git.sh
+++ b/bin/update_git.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd $SPLUNK_HOME/etc/apps/corona_virus/git/COVID-19/
-git checkout master
+git checkout master 2>&1
 cd $SPLUNK_HOME/etc/apps/corona_virus
-git submodule foreach git pull origin master
+git submodule foreach git pull origin master 2>&1

--- a/bin/update_git.sh
+++ b/bin/update_git.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 cd $SPLUNK_HOME/etc/apps/corona_virus/git/COVID-19/
 git checkout master
 cd $SPLUNK_HOME/etc/apps/corona_virus

--- a/lookups/latest_daily.csv
+++ b/lookups/latest_daily.csv
@@ -1,0 +1,1 @@
+../git/COVID-19/csse_covid_19_data/csse_covid_19_daily_reports/05-08-2020.csv


### PR DESCRIPTION
Hi,

  Found that _internal was getting error messages everytime update_git.sh ran.  Turns out git sends some of its output to stderr instead of stdout.  This probably makes sense in some situations where the script running git wants to do something with the output, but here just adds confusion to _internal, and means the output of the scripted input is missing some data.

  Fixed by adding 2>&1 to the end of the two lines running git.

  In the process I got a bit pedantic and added #!/bin/sh to the first line of both scripts....just because.  :)

  Finally since lookups/update_daily.sh was not in the repository, I added the link so git status is cleaner. 

Don