### PR TITLE
Add worldwide vaccination dataset & dashboard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "git/coronavirus-data"]
 	path = git/coronavirus-data
 	url = https://github.com/nychealth/coronavirus-data
+[submodule "git/owid"]
+	path = git/owid
+	url = https://github.com/owid/covid-19-data

--- a/default/data/ui/nav/default.xml
+++ b/default/data/ui/nav/default.xml
@@ -3,6 +3,7 @@
   <view name="covid-19" />
   <view name="coronavirus_timelapse" />
   <view name="confirmed_cases_location_overlay" />
+  <view name="vaccinations" />
   <view name="search"/>
   <view name="dashboards" />
 </nav>

--- a/default/data/ui/views/vaccinations.xml
+++ b/default/data/ui/views/vaccinations.xml
@@ -1,0 +1,191 @@
+<dashboard theme="dark">
+  <label>Vaccinations</label>
+  <description>The data for this dashboard is collated by World in Data. For information on the source data please visit https://github.com/owid/covid-19-data/blob/master/public/data/vaccinations/locations.csv</description>
+  <row>
+    <panel>
+      <title>Total Worldwide Vaccinations</title>
+      <chart>
+        <search>
+          <query>| inputlookup vaccinations.csv
+| rename "location" as Country
+| eval _time=strptime(date,"%Y-%m-%d") | search Country="World"
+| timechart latest(total_vaccinations) as total_vaccinations by Country |filldown | addtotals | table _time Total</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="charting.chart">line</option>
+        <option name="charting.drilldown">none</option>
+        <option name="refresh.display">progressbar</option>
+      </chart>
+    </panel>
+    <panel>
+      <table>
+        <search>
+          <query>| inputlookup vaccinations.csv
+| fields - Lat Long "Province/State"
+| rename "location" as Country
+| eval _time=strptime(date,"%Y-%m-%d") | search Country!="World"
+| timechart latest(total_vaccinations) as total_vaccinations by Country
+| filldown * | untable _time Country total_vaccinations
+| chart sparkline(avg(total_vaccinations),24h) AS sparkline latest(total_vaccinations) AS "Total Vaccinations" by Country | sort 0 - "Total Vaccinations"</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="count">20</option>
+        <option name="dataOverlayMode">none</option>
+        <option name="drilldown">none</option>
+        <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="rowNumbers">false</option>
+        <option name="totalsRow">false</option>
+        <option name="wrap">true</option>
+      </table>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Percentage of Population Vaccinated by Country</title>
+      <chart>
+        <search>
+          <query>| inputlookup vaccinations.csv
+| eval _time=strptime(date,"%Y-%m-%d")
+
+| timechart span=1d latest(total_vaccinations_per_hundred) AS total_vaccinations_per_hundred by location
+| filldown</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
+        <option name="charting.axisTitleX.visibility">visible</option>
+        <option name="charting.axisTitleY.visibility">visible</option>
+        <option name="charting.axisTitleY2.visibility">visible</option>
+        <option name="charting.axisX.abbreviation">none</option>
+        <option name="charting.axisX.scale">linear</option>
+        <option name="charting.axisY.abbreviation">none</option>
+        <option name="charting.axisY.scale">linear</option>
+        <option name="charting.axisY2.abbreviation">none</option>
+        <option name="charting.axisY2.enabled">0</option>
+        <option name="charting.axisY2.scale">inherit</option>
+        <option name="charting.chart">line</option>
+        <option name="charting.chart.bubbleMaximumSize">50</option>
+        <option name="charting.chart.bubbleMinimumSize">10</option>
+        <option name="charting.chart.bubbleSizeBy">area</option>
+        <option name="charting.chart.nullValueMode">gaps</option>
+        <option name="charting.chart.showDataLabels">none</option>
+        <option name="charting.chart.sliceCollapsingThreshold">0.01</option>
+        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.style">shiny</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.layout.splitSeries">0</option>
+        <option name="charting.layout.splitSeries.allowIndependentYRanges">0</option>
+        <option name="charting.legend.labelStyle.overflowMode">ellipsisMiddle</option>
+        <option name="charting.legend.mode">standard</option>
+        <option name="charting.legend.placement">right</option>
+        <option name="charting.lineWidth">2</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+      </chart>
+    </panel>
+    <panel>
+      <title>Total Vaccinations by Country</title>
+      <chart>
+        <search>
+          <query>| inputlookup vaccinations.csv
+| eval _time=strptime(date,"%Y-%m-%d")
+
+| timechart span=1d latest(total_vaccinations) AS total_vaccinations by location | filldown</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
+        <option name="charting.axisTitleX.visibility">visible</option>
+        <option name="charting.axisTitleY.visibility">visible</option>
+        <option name="charting.axisTitleY2.visibility">visible</option>
+        <option name="charting.axisX.abbreviation">none</option>
+        <option name="charting.axisX.scale">linear</option>
+        <option name="charting.axisY.abbreviation">none</option>
+        <option name="charting.axisY.scale">linear</option>
+        <option name="charting.axisY2.abbreviation">none</option>
+        <option name="charting.axisY2.enabled">0</option>
+        <option name="charting.axisY2.scale">inherit</option>
+        <option name="charting.chart">line</option>
+        <option name="charting.chart.bubbleMaximumSize">50</option>
+        <option name="charting.chart.bubbleMinimumSize">10</option>
+        <option name="charting.chart.bubbleSizeBy">area</option>
+        <option name="charting.chart.nullValueMode">gaps</option>
+        <option name="charting.chart.showDataLabels">none</option>
+        <option name="charting.chart.sliceCollapsingThreshold">0.01</option>
+        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.style">shiny</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.layout.splitSeries">0</option>
+        <option name="charting.layout.splitSeries.allowIndependentYRanges">0</option>
+        <option name="charting.legend.labelStyle.overflowMode">ellipsisMiddle</option>
+        <option name="charting.legend.mode">standard</option>
+        <option name="charting.legend.placement">right</option>
+        <option name="charting.lineWidth">2</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+      </chart>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Daily Vaccinations</title>
+      <chart>
+        <search>
+          <query>| inputlookup vaccinations.csv
+| eval _time=strptime(date,"%Y-%m-%d")
+ 
+| eval perc_vaccinated=(total_vaccinations/population)*100
+| timechart span=1d latest(daily_vaccinations) AS daily_vaccinations by location</query>
+          <earliest>0</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
+        </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
+        <option name="charting.axisTitleX.visibility">visible</option>
+        <option name="charting.axisTitleY.visibility">visible</option>
+        <option name="charting.axisTitleY2.visibility">visible</option>
+        <option name="charting.axisX.abbreviation">none</option>
+        <option name="charting.axisX.scale">linear</option>
+        <option name="charting.axisY.abbreviation">none</option>
+        <option name="charting.axisY.scale">linear</option>
+        <option name="charting.axisY2.abbreviation">none</option>
+        <option name="charting.axisY2.enabled">0</option>
+        <option name="charting.axisY2.scale">inherit</option>
+        <option name="charting.chart">line</option>
+        <option name="charting.chart.bubbleMaximumSize">50</option>
+        <option name="charting.chart.bubbleMinimumSize">10</option>
+        <option name="charting.chart.bubbleSizeBy">area</option>
+        <option name="charting.chart.nullValueMode">gaps</option>
+        <option name="charting.chart.showDataLabels">none</option>
+        <option name="charting.chart.sliceCollapsingThreshold">0.01</option>
+        <option name="charting.chart.stackMode">default</option>
+        <option name="charting.chart.style">shiny</option>
+        <option name="charting.drilldown">none</option>
+        <option name="charting.layout.splitSeries">0</option>
+        <option name="charting.layout.splitSeries.allowIndependentYRanges">0</option>
+        <option name="charting.legend.labelStyle.overflowMode">ellipsisMiddle</option>
+        <option name="charting.legend.mode">standard</option>
+        <option name="charting.legend.placement">right</option>
+        <option name="charting.lineWidth">2</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="trellis.enabled">0</option>
+        <option name="trellis.scales.shared">1</option>
+        <option name="trellis.size">medium</option>
+      </chart>
+    </panel>
+  </row>
+</dashboard>

--- a/lookups/vaccinations.csv
+++ b/lookups/vaccinations.csv
@@ -1,0 +1,1 @@
+../git/owid/public/data/vaccinations/vaccinations.csv


### PR DESCRIPTION
This merge will add the OWID (https://github.com/owid/covid-19-data/) data source, which contains a source of the vaccination statistics collated worldwide and listed by country.
An additional dashboard (simple) shows the rollout of the vaccine across different countries. 
![dashboard](https://user-images.githubusercontent.com/5527349/103733497-c964e280-4fe1-11eb-9b78-8abcceb22814.png)